### PR TITLE
Adding a generate_token API route and GUI. 

### DIFF
--- a/sentinel-web/generate_token.html
+++ b/sentinel-web/generate_token.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ComfyUI Sentinel - Register</title>
+
+    <link rel="icon" href="/sentinel/assets/icon.ico" type="image/x-icon">
+
+    <link rel="stylesheet" type="text/css" href="/sentinel/css/styles.css">
+</head>
+
+<body">
+    <div class="container">
+        <img class="logo" src="/sentinel/assets/logo_transparent.png" alt="Transparent Logo">
+        <h1 class="title generate">Generate Token</h1>
+        <form id="generate-form" onsubmit="generate(event)">
+                <div class="form-field">
+                    <label for="username">Username:</label>
+                    <input type="text" id="username" name="username" required>
+                </div>
+                <div class="form-field">
+                    <label for="password">Password:</label>
+                    <input type="password" id="password" name="password" required>
+                </div>
+                <div class="form-field">
+                    <label for="expire_hours">Expiration (in hours):</label>
+                    <input type="integer" id="expire_hours" name="expire_hours" value="720" required>
+                </div>
+            <div class="form-field" id="register-link">
+                <a href="/login">Back to Login</a>
+            </div>
+            <button class="btn" type="submit">Generate</button>
+        </form>
+    </div>
+    <div class="toast-container" id="toasts"></div>
+</body>
+<script src="/sentinel/js/auth.js"></script>
+
+</html>

--- a/sentinel-web/js/auth.js
+++ b/sentinel-web/js/auth.js
@@ -82,6 +82,37 @@ function validateRegisterForm() {
   return true;
 }
 
+function validateGenerateForm() {
+  const usernameField = document.getElementById("username");
+  const passwordField = document.getElementById("password");
+  const expireField = document.getElementById("expire_hours");
+  const username = usernameField.value;
+  const password = passwordField.value;
+  const expire_hours = expireField.value;
+
+  usernameField.classList.remove("error");
+  passwordField.classList.remove("error");
+  expireField.classList.remove("error");
+
+  if (/[^0-9]/.test(expire_hours) || /\s/.test(expire_hours)) {
+    addToast(
+      "Expiration can only contain numbers",
+      "error"
+    );
+    expireField.classList.add("error");
+    return false;
+  }
+
+  return true;
+}
+
+Object.defineProperty(String.prototype, 'capitalize', {
+  value: function() {
+    return this.charAt(0).toUpperCase() + this.slice(1);
+  },
+  enumerable: false
+});
+
 function disableForm(duration, action) {
   const form = document.getElementById(`${action}-form`);
   const button = form.querySelector("button[type='submit']");
@@ -105,13 +136,13 @@ function disableForm(duration, action) {
       if (remainingTime <= 0) {
         clearInterval(countdownInterval);
         button.disabled = false;
-        button.textContent = action === "login" ? "Login" : "Register";
+        button.textContent = action.capitalize();
         // fields.forEach((field) => (field.disabled = false));
       }
     }, 1000);
   } else {
     button.disabled = false;
-    button.textContent = action === "login" ? "Login" : "Register";
+    button.textContent = action.capitalize();
   }
 }
 
@@ -310,6 +341,48 @@ async function register(event) {
     }
   }
 }
+
+async function generate(event) {
+  event.preventDefault();
+
+  if (validateGenerateForm() && !isTimedOut()) {
+    const button = event.submitter;
+    const form = document.getElementById("generate-form");
+    const formData = new FormData(form);
+
+    try {
+      button.disabled = true;
+      button.textContent = "Sending...";
+
+      const response = await fetch("/generate_token", {
+        method: "POST",
+        body: formData,
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        alert("Generated token:\n"+result.jwt_token+"\nCopy it because it will not be shown again.");
+        addToast(result.message, "success");
+        updateFailedAttempts(response.status, result, "generate");
+        //window.location.href = "/login";
+        //form.reset();
+      } else {
+        addToast(
+          result.error || result.message || "Generation failed",
+          "error"
+        );
+      }
+      updateFailedAttempts(response.status, result, "generate");
+    } catch (error) {
+      addToast("An error occurred: " + error.message, "error");
+      button.disabled = false;
+      button.textContent = "Generate";
+    }
+  }
+}
+
+
 
 loadTimeoutFromStorage(
   window.location.pathname === "/login" ? "login" : "register"

--- a/sentinel-web/login.html
+++ b/sentinel-web/login.html
@@ -27,6 +27,9 @@
             <div class="form-field">
                 <a href="/register">Register a New User</a>
             </div>
+            <div class="form-field">
+                <a href="/generate_token">Generate API token for User</a>
+            </div>
             <button class="btn" type="submit">Login</button>
         </form>
     </div>

--- a/utils/jwt_auth.py
+++ b/utils/jwt_auth.py
@@ -34,10 +34,12 @@ class JWTAuth:
             return auth_header[len("Bearer ") :]
         return request.cookies.get("jwt_token")
 
-    def create_access_token(self, data: dict) -> str:
+    def create_access_token(self, data: dict,expire_minutes=None) -> str:
         """Create a JWT access token."""
         to_encode = data.copy()
-        expire = datetime.now(timezone.utc) + timedelta(minutes=self.expire_minutes)
+        if expire_minutes==None:
+            expire_minutes=self.expire_minutes
+        expire = datetime.now(timezone.utc) + timedelta(minutes=expire_minutes)
         to_encode.update({"exp": expire})
         return jwt.encode(to_encode, self.__secret_key, algorithm=self.algorithm)
 


### PR DESCRIPTION
Trying to  solve #6 

- Creating a generate_token POST route taking three parameters:
  - username
  - password
  - expire_hours (the expiration time in hours)
that return a JWT token for that user with the corresponding expiration date

the create_acces_token method was modified to have the possibility to choose the expiration time. If not specified, it choose the value defined in the config.json (previous behavior)

- Creating a generate_token GET route that return the generate_token.html template page
The form is validated by JS (I followed the design pattern of the register/login pages)

- The login template now shows a link to the generate page.

I tested it on my installation.

I hope you will accept it :)

Thanks again for this great module.

Kind regards,

Antoine